### PR TITLE
Add tag to ignore the column during migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Active string `migu:"default:yes"`
 Body string `migu:"size:512"` // VARCHAR(512)
 ```
 
+#### IGNORE
+
+```go
+Body string `migu:"-"` // Ignore during migration
+```
+
 ### Specify the multiple struct field's tags
 
 To specify the multiple struct field's tags to the single column, join with commas.

--- a/migu.go
+++ b/migu.go
@@ -62,6 +62,9 @@ func Diff(db *sql.DB, filename string, src interface{}) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
+			if f.Ignore {
+				continue
+			}
 			for _, ident := range fld.Names {
 				field := *f
 				field.Name = ident.Name
@@ -129,6 +132,7 @@ type field struct {
 	Unique        bool
 	PrimaryKey    bool
 	AutoIncrement bool
+	Ignore        bool
 	Default       string
 	Size          uint64
 }
@@ -186,6 +190,7 @@ const (
 	tagAutoIncrement = "autoincrement"
 	tagUnique        = "unique"
 	tagSize          = "size"
+	tagIgnore        = "-"
 )
 
 func getTableMap(db *sql.DB) (map[string][]*columnSchema, error) {
@@ -497,6 +502,8 @@ func parseStructTag(f *field, tag reflect.StructTag) error {
 			f.AutoIncrement = true
 		case tagUnique:
 			f.Unique = true
+		case tagIgnore:
+			f.Ignore = true
 		case tagSize:
 			if len(optval) < 2 {
 				return fmt.Errorf("`size' tag must specify the parameter")


### PR DESCRIPTION
Hi.
`migu` is very useful product, but I sometimes want to ignore struct parameter during migration.

```
type User struct {
	Name string
	Email string
	Admn bool `migu:"-"` // ignore during migration
}
```

How about that?

