### PR TITLE
Use snaker for commonInitialisms

### DIFF
--- a/migu.go
+++ b/migu.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/naoina/migu/dialect"
+	"github.com/serenize/snaker"
 )
 
 // Sync synchronizes the schema between Go's struct and the database.
@@ -83,7 +84,7 @@ func Diff(db *sql.DB, filename string, src interface{}) ([]string, error) {
 	for _, name := range names {
 		model := structMap[name]
 		columns, ok := tableMap[name]
-		tableName := toSnakeCase(name)
+		tableName := snaker.CamelToSnake(name)
 		if !ok {
 			columns := make([]string, len(model))
 			for i, f := range model {
@@ -95,7 +96,7 @@ func Diff(db *sql.DB, filename string, src interface{}) ([]string, error) {
 		} else {
 			table := map[string]*columnSchema{}
 			for _, column := range columns {
-				table[toCamelCase(column.ColumnName)] = column
+				table[snaker.SnakeToCamel(column.ColumnName)] = column
 			}
 			var modifySQLs []string
 			var dropSQLs []string
@@ -110,14 +111,14 @@ func Diff(db *sql.DB, filename string, src interface{}) ([]string, error) {
 			}
 			migrations = append(migrations, append(dropSQLs, modifySQLs...)...)
 			for _, f := range table {
-				migrations = append(migrations, fmt.Sprintf(`ALTER TABLE %s DROP %s`, d.Quote(tableName), d.Quote(toSnakeCase(f.ColumnName))))
+				migrations = append(migrations, fmt.Sprintf(`ALTER TABLE %s DROP %s`, d.Quote(tableName), d.Quote(snaker.CamelToSnake(f.ColumnName))))
 			}
 		}
 		delete(structMap, name)
 		delete(tableMap, name)
 	}
 	for name := range tableMap {
-		migrations = append(migrations, fmt.Sprintf(`DROP TABLE %s`, d.Quote(toSnakeCase(name))))
+		migrations = append(migrations, fmt.Sprintf(`DROP TABLE %s`, d.Quote(snaker.CamelToSnake(name))))
 	}
 	return migrations, nil
 }
@@ -240,7 +241,7 @@ ORDER BY TABLE_NAME, ORDINAL_POSITION`
 		); err != nil {
 			return nil, err
 		}
-		tableName := toCamelCase(schema.TableName)
+		tableName := snaker.SnakeToCamel(schema.TableName)
 		tableMap[tableName] = append(tableMap[tableName], schema)
 		if tableIndex, exists := indexMap[schema.TableName]; exists {
 			if info, exists := tableIndex[schema.ColumnName]; exists {
@@ -362,7 +363,7 @@ func detectTypeName(n ast.Node) (string, error) {
 
 func columnSQL(d dialect.Dialect, f *field) string {
 	colType, null := d.ColumnType(f.Type, f.Size, f.AutoIncrement)
-	column := []string{d.Quote(toSnakeCase(f.Name)), colType}
+	column := []string{d.Quote(snaker.CamelToSnake(f.Name)), colType}
 	if !null {
 		column = append(column, "NOT NULL")
 	}
@@ -468,7 +469,7 @@ func structAST(name string, schemas []*columnSchema) (ast.Decl, error) {
 		Tok: token.TYPE,
 		Specs: []ast.Spec{
 			&ast.TypeSpec{
-				Name: ast.NewIdent(toCamelCase(name)),
+				Name: ast.NewIdent(snaker.SnakeToCamel(name)),
 				Type: &ast.StructType{
 					Fields: &ast.FieldList{
 						List: fields,
@@ -539,7 +540,7 @@ func (schema *columnSchema) fieldAST() (*ast.Field, error) {
 	}
 	field := &ast.Field{
 		Names: []*ast.Ident{
-			ast.NewIdent(toCamelCase(schema.ColumnName)),
+			ast.NewIdent(snaker.SnakeToCamel(schema.ColumnName)),
 		},
 		Type: ast.NewIdent(types[0]),
 	}

--- a/util.go
+++ b/util.go
@@ -1,52 +1,5 @@
 package migu
 
-import (
-	"bytes"
-	"unicode"
-)
-
-// toCamelCase returns a copy of the string s with all Unicode letters mapped to their camel case.
-// It will convert to upper case previous letter of '_' and first letter, and remove letter of '_'.
-func toCamelCase(s string) string {
-	if s == "" {
-		return ""
-	}
-	result := make([]rune, 0, len(s))
-	upper := false
-	for _, r := range s {
-		if r == '_' {
-			upper = true
-			continue
-		}
-		if upper {
-			result = append(result, unicode.ToUpper(r))
-			upper = false
-			continue
-		}
-		result = append(result, r)
-	}
-	result[0] = unicode.ToUpper(result[0])
-	return string(result)
-}
-
-// toSnakeCase returns a copy of the string s with all Unicode letters mapped to their snake case.
-// It will insert letter of '_' at position of previous letter of uppercase and all
-// letters convert to lower case.
-func toSnakeCase(s string) string {
-	if s == "" {
-		return ""
-	}
-	var result bytes.Buffer
-	result.WriteRune(unicode.ToLower(rune(s[0])))
-	for _, c := range s[1:] {
-		if unicode.IsUpper(c) {
-			result.WriteRune('_')
-		}
-		result.WriteRune(unicode.ToLower(c))
-	}
-	return result.String()
-}
-
 func inStrings(a []string, s string) bool {
 	for _, v := range a {
 		if v == s {


### PR DESCRIPTION
I have a problem with the conversion of the struct parameter name ID and UUID like below.

```
type User struct {
    ID int
    UUID string
    Email string
}
```

Here is the query result.

```
--------applying--------
  CREATE TABLE `user` (
    `i_d` INT NOT NULL,
    `u_u_i_d` VARCHAR(255) NOT NULL,
    `email` VARCHAR(255) NOT NULL
  )
```

ID to `i_d` and UUID to `u_u_i_d`.These are not expected.
So, I found [serenize/snaker](https://github.com/serenize/snaker) .
snaker resolves that `commonInitialisms` issues If you forgive the external package dependencies...
How about that?