### PR TITLE
Support unavailable data type of float

### DIFF
--- a/migu.go
+++ b/migu.go
@@ -1042,7 +1042,7 @@ func (schema *columnSchema) GoFieldTypes() (goTypes []string, typ string, err er
 			return []string{"*time.Time"}, "", nil
 		}
 		return []string{"time.Time"}, "", nil
-	case "double":
+	case "double", "float":
 		if schema.isNullable() {
 			return []string{"*float64", "sql.NullFloat64", "*float32"}, "", nil
 		}

--- a/migu_test.go
+++ b/migu_test.go
@@ -1145,6 +1145,15 @@ func TestFprint(t *testing.T) {
 			"	Balance float64 `migu:\"type:decimal,precision:65,scale:2\"`\n" +
 			"}\n\n",
 		},
+		{[]string{
+			"CREATE TABLE user (\n" +
+				"brightness float NOT NULL DEFAULT '0.1'\n" +
+				")",
+		}, "//+migu\n" +
+			"type User struct {\n" +
+			"	Brightness float64 `migu:\"default:0.1\"`\n" +
+			"}\n\n",
+		},
 	} {
 		v := v
 		func() {


### PR DESCRIPTION
Support float type

```
$ migu dump -h 127.0.0.1 -u root {db_name} ./dump.go
BUG: unexpected data type: float
```