### PR TITLE
fix: Alter will always execute when sync on column with comment

### DIFF
--- a/migu.go
+++ b/migu.go
@@ -286,7 +286,7 @@ func newField(d dialect.Dialect, typeName string, f *ast.Field) (*field, error) 
 		}
 	}
 	if f.Comment != nil {
-		ret.Comment = strings.TrimSpace(f.Comment.Text())
+		ret.Comment = strings.Trim(strings.TrimSpace(f.Comment.Text()), "/ ")
 	}
 	if ret.Column == "" {
 		ret.Column = stringutil.ToSnakeCase(ret.Name)

--- a/migu_test.go
+++ b/migu_test.go
@@ -113,14 +113,14 @@ func TestDiff(t *testing.T) {
 		}
 	})
 
-	t.Run("multiple-column primary key", func(t *testing.T) {
+	t.Run("multiple-column primary key and comment", func(t *testing.T) {
 		before(t)
 		src := strings.Join([]string{
 			"package migu_test",
 			"//+migu",
 			"type User struct {",
 			"	UserID uint64 `migu:\"pk\"`",
-			"	ProfileID uint64 `migu:\"pk\"`",
+			"	ProfileID uint64 `migu:\"pk\"` //max 10 digits",
 			"}",
 		}, "\n")
 		results, err := migu.Diff(db, "", src)
@@ -132,7 +132,7 @@ func TestDiff(t *testing.T) {
 			strings.Join([]string{
 				"CREATE TABLE `user` (",
 				"  `user_id` BIGINT UNSIGNED NOT NULL,",
-				"  `profile_id` BIGINT UNSIGNED NOT NULL,",
+				"  `profile_id` BIGINT UNSIGNED NOT NULL COMMENT 'max 10 digits',",
 				"  PRIMARY KEY (`user_id`, `profile_id`)",
 				")",
 			}, "\n"),


### PR DESCRIPTION
hi! I fixed sync bug. AlterQuery will always execute when sync on column with comment.

```
migu sync -h 127.0.0.1 -u root --dry-run {db_name} dump.go
--------dry-run applying--------
ALTER TABLE `users` CHANGE `name` string UNSIGNED NOT NULL COMMENT 'FirstName.LastName'
--------dry-run done 0.000s--------

```