### PR TITLE
ENUM and SET supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,21 @@ CREATE TABLE `user` (
 --------dry-run done 0.000s--------
 ```
 
+### Definition separator
+
+If you want to specify a column type such as `ENUM` , `SET` (only MySQL) types, use `separator` annotation tag.
+
+Then you can use type of emun definition with comma in struct. (such as `enum('A','B','O','AB','')`)
+
+```
+package model
+
+//+migu separator:";"
+type User struct {
+    BloodType *string `migu:"column:blood;type:enum('A','B','O','AB')"`
+}
+```
+
 ## Supported database
 
 * MariaDB/MySQL

--- a/annotation.go
+++ b/annotation.go
@@ -10,8 +10,9 @@ import (
 )
 
 type annotation struct {
-	Table  string
-	Option string
+	Table     string
+	Option    string
+	Separator string
 }
 
 func parseAnnotation(g *ast.CommentGroup) (*annotation, error) {
@@ -47,6 +48,12 @@ func parseAnnotation(g *ast.CommentGroup) (*annotation, error) {
 					return nil, fmt.Errorf("migu: BUG: %v", err)
 				}
 				a.Option = s
+			case "separator":
+				s, err := parseString(v)
+				if err != nil {
+					return nil, fmt.Errorf("migu: BUG: %v", err)
+				}
+				a.Separator = s
 			default:
 				return nil, fmt.Errorf("migu: unsupported annotation: %v", k)
 			}

--- a/dialect/mysql_schema.go
+++ b/dialect/mysql_schema.go
@@ -104,13 +104,22 @@ func (schema *mysqlColumnSchema) GoType() string {
 			return "*float64"
 		}
 		return "float64"
+	case "enum", "set":
+		if schema.IsNullable() {
+			return "*string"
+		}
+		return "string"
 	}
+
 	return "interface{}"
 }
 
 func (schema *mysqlColumnSchema) DataType() string {
 	if schema.dataType == "tinyint" && schema.columnType == "tinyint(1)" {
 		return "tinyint(1)"
+	}
+	if schema.dataType == "enum" || schema.dataType == "set" {
+		return schema.columnType
 	}
 	return schema.dataType
 }
@@ -182,4 +191,8 @@ func (schema *mysqlColumnSchema) Comment() (string, bool) {
 
 func (schema *mysqlColumnSchema) isUnsigned() bool {
 	return strings.Contains(schema.columnType, "unsigned")
+}
+
+func (schema *mysqlColumnSchema) IsEnumerated() bool {
+	return schema.dataType == "enum" || schema.dataType == "set"
 }

--- a/dialect/schema.go
+++ b/dialect/schema.go
@@ -16,4 +16,5 @@ type ColumnSchema interface {
 	IsNullable() bool
 	Extra() (string, bool)
 	Comment() (string, bool)
+	IsEnumerated() bool
 }


### PR DESCRIPTION
I want to use ENUM type, but migu does not supported.

This request is ENUM and SET type supports.

I worry about migu's definition separator (comma separated).

MySQL ENUM spec is using comma. (about `ENUM('A','b')`)

I added it to the annotation because I needed to change the separator.

Separator is `;` like [gorm](https://github.com/jinzhu/gorm)

I think that using annotation is not best solution. Now, the annotation is option for table definition directly.

What do you think about it?
And if you have any idea, I implemet that. 